### PR TITLE
Fix infinite location request loop in Firefox

### DIFF
--- a/src/components/map/LocationMarker.tsx
+++ b/src/components/map/LocationMarker.tsx
@@ -79,12 +79,26 @@ export default memo(() => {
         }
     };
 
+    const moveToLocation = (location: [number, number]) => {
+        if (map) {
+            const zoom = map.getZoom();
+
+            map.easeTo({
+                center: location,
+                zoom: zoom > 15 ? zoom : 15,
+            });
+        }
+    }
+
     const moveToUser = () => {
         if (!userPermitted) {
             navigator.geolocation.getCurrentPosition(
-                () => {
+                (location) => {
+                    const { coords } = location;
+
                     setUserPermitted(true);
-                    moveToUser();
+                    handleLocation(location);
+                    moveToLocation([coords.longitude, coords.latitude]);
                 },
                 (e) => {
                     console.error(e);
@@ -93,13 +107,8 @@ export default memo(() => {
             );
         }
 
-        if (userLocation?.[0] && map) {
-            const zoom = map.getZoom();
-
-            map.easeTo({
-                center: userLocation,
-                zoom: zoom > 15 ? zoom : 15,
-            });
+        if (userLocation?.[0]) {
+            moveToLocation(userLocation);
         }
     };
 


### PR DESCRIPTION
Currently in Firefox for Android the code responsible for panning the map to the user's location goes into a funny infinite loop and does not move the map. `moveToUser()` function inside the _successCallback_ of `Geolocation.getCurrentPosition()` call in `moveToUser()` is executed before Reacts updates the `userPermitted` state variable.

Below you can see the effect. Note that the location indicator in the upper left corner is blinking way faster than shown in the video, but I chose 30 FPS to make the file a bit smaller.

<details>
<summary>Screen recording showing location request loop</summary>

https://github.com/user-attachments/assets/78b8b1ab-5ae0-4690-81d8-8c84c6b916cf

</details>

With changes from this PR, the map is moved right after the first coordinates are received. There are still 2 or 3 (if I pause in debugger) permission prompts, since `watchPosition` calls Geolocation API 2 more times. Usually those 2 calls result in only one prompt.

<details>
<summary>Behaviour with changes from this PR</summary>

https://github.com/user-attachments/assets/139af52e-a00b-4c55-99ca-f4ae2121b876

</details>

There probably is a better way to solve this problem (call only `Geolocation.watchPosition()`?), but from the two that I've tried (the other is https://github.com/krzysdz/zbiorkom.live/commit/c69ef6ca38fa60e1d7ef2679214d318af0e977dd), this one seems better, as it moves the map to position after the first permission prompt is accepted and it doesn't introduce new hooks.