### PR TITLE
fix executionLine being unaligned when font is not bolded

### DIFF
--- a/src/components/pages/Executions/Execution.tsx
+++ b/src/components/pages/Executions/Execution.tsx
@@ -93,7 +93,10 @@ const TripTime = ({ scheduled, delay = -1 }: { scheduled: number; delay?: number
                     "delay-" +
                     (delayExists ? (delayMinutes ? (delay > 0 ? "delayed" : "early") : "none") : "unknown")
                 }
-                style={{ fontWeight: delayExists ? "bold" : "normal" }}
+                style={{
+                    fontWeight: delayExists ? "bold" : "normal",
+                    marginLeft: delayExists ? 0 : 0.5,
+                }}
             >
                 {getTime(scheduled + delay)}
             </span>


### PR DESCRIPTION
before:
<img width="582" height="218" alt="image" src="https://github.com/user-attachments/assets/92fb9a35-d1a2-4dab-85ae-c7a079e8fc39" />
after:
<img width="590" height="221" alt="image" src="https://github.com/user-attachments/assets/f95f71f2-48b6-4972-9810-0ddb946cd446" />
