### PR TITLE
Matchowanie wyników `/getRoute` po `direction`

### DIFF
--- a/src/components/pages/Route.tsx
+++ b/src/components/pages/Route.tsx
@@ -36,7 +36,7 @@ export default () => {
         city: city!,
         options: {
             filterRoutes: [route!],
-            filterDirection: direction,
+            filterDirection: data?.[ERouteInfo.directions][direction]?.[ERouteDirection.direction],
         },
     });
 


### PR DESCRIPTION
**Co**:
- matchowanie wyników z `/getRoute` po `direction`, a nie po indeksie w liście

**Dlaczego**:
- fixes https://github.com/DomeQdev/zbiorkom.live/issues/50